### PR TITLE
Add ability to minimised tray

### DIFF
--- a/src/components/reactions/ReactionTray.vue
+++ b/src/components/reactions/ReactionTray.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="main-tray">
-    <div class="tray-inner" :class="{ open: trayOpen }">
+    <MinimiseButton />
+    <div class="tray-inner"
+      v-bind:class="[{ open: trayOpen }, trayMimimised ]"
+    >
       <SettingsButton />
       <div class="divider"></div>
       <ReactionsButton />
@@ -17,6 +20,7 @@
 </template>
 
 <script>
+import MinimiseButton from "./buttons/MinimiseButton";
 import HandUpButton from "./buttons/HandUpButton";
 import ResponseButton from "./buttons/ResponseButton";
 import ReactionsButton from "./buttons/ReactionsButton";
@@ -26,6 +30,7 @@ import SettingsButton from "./buttons/SettingsButton";
 
 export default {
   components: {
+    MinimiseButton,
     HandUpButton,
     ResponseButton,
     ReactionsButton,
@@ -36,6 +41,9 @@ export default {
   computed: {
     trayOpen() {
       return this.$store.state.reactions || this.$store.state.settings;
+    },
+    trayMimimised: function() {
+      return this.$store.state.minimised ? 'tray-inner--minimised' : '';
     }
   }
 };
@@ -43,8 +51,8 @@ export default {
 
 <style lang="scss">
 .main-tray {
-  background-color: rgba(0, 0, 0, 0.541);
-  box-shadow: 0 1px 2px 0 rgba(60, 64, 67, 0.302), 0 2px 6px 2px rgba(60, 64, 67, 0.149);
+  // background-color: rgba(0, 0, 0, 0.541);
+  // box-shadow: 0 1px 2px 0 rgba(60, 64, 67, 0.302), 0 2px 6px 2px rgba(60, 64, 67, 0.149);
   right: auto;
   animation-name: fade;
   animation-duration: 0.5s;
@@ -74,6 +82,12 @@ export default {
   background-color: #fff;
   display: flex;
   border-radius: 0 0 8px;
+  transition-duration: 0.25s;
+  transition-property: transform border-radius;
+  transition-timing-function: cubic-bezier(0.4, 0, 1, 1);
+}
+.tray-inner--minimised{ 
+  transform: translateX(-999px);
 }
 
 .divider {

--- a/src/components/reactions/buttons/MinimiseButton.vue
+++ b/src/components/reactions/buttons/MinimiseButton.vue
@@ -1,0 +1,83 @@
+<template>
+    <a 
+    class="uArJ5e UQuaGc kCyAyd kW31ib foXzLb tray-button minimise-btn" 
+    tabindex="0" aria-label="Minimise tray" role="button"
+    v-bind:class="toggleIcon"
+    @keyup.enter="toggleTrayVisibility">
+      <div class="e19J0b CeoRYc" @click.self="toggleTrayVisibility"></div>
+      <svg style="display: none;">
+        <symbol id="icon-circle-right" viewBox="0 0 32 32">
+          <path d="M16 0c-8.837 0-16 7.163-16 16s7.163 16 16 16 16-7.163 16-16-7.163-16-16-16zM16 29c-7.18 0-13-5.82-13-13s5.82-13 13-13 13 5.82 13 13-5.82 13-13 13z"></path>
+          <path d="M11.086 22.086l2.829 2.829 8.914-8.914-8.914-8.914-2.828 2.828 6.086 6.086z"></path>
+        </symbol>
+        <symbol id="icon-circle-left" viewBox="0 0 32 32">
+          <path d="M16 32c8.837 0 16-7.163 16-16s-7.163-16-16-16-16 7.163-16 16 7.163 16 16 16zM16 3c7.18 0 13 5.82 13 13s-5.82 13-13 13-13-5.82-13-13 5.82-13 13-13z"></path>
+          <path d="M20.914 9.914l-2.829-2.829-8.914 8.914 8.914 8.914 2.828-2.828-6.086-6.086z"></path>
+        </symbol>
+      </svg>
+      <span class="DPvwYc sm8sCf SX67K" aria-hidden="true">
+        <svg class="icon icon-circle-left"><use xlink:href="#icon-circle-left"></use></svg>
+        <svg class="icon icon-circle-right"><use xlink:href="#icon-circle-right"></use></svg>
+      </span>
+    </a>
+</template>
+
+<script>
+
+export default {
+  components: {
+  },
+  methods: {
+    toggleTrayVisibility() {
+      if (this.$store.state.minimised) {
+        this.$store.dispatch("setMinimised" , false);
+          return true
+      } else {
+        this.$store.dispatch("setMinimised" , true);
+        return false
+      }
+    }
+  },
+  computed: {
+    toggleIcon: function () {
+      return this.$store.state.minimised ? 'minimise-btn--active' : ''
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+
+.icon {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  stroke-width: 0;
+  stroke: currentColor;
+  fill: currentColor;
+}
+
+.icon-circle-right {
+  display: none;
+}
+.minimise-btn {
+  background: #fff;
+  position: relative;
+  z-index: 1;
+  
+  &:hover,
+  &:focus {
+     background-color: rgb(219, 241, 237);
+  }
+
+  &--active{
+    border-radius: 0 0 8px;
+    .icon-circle-right {
+      display: inline-block;
+    }
+    .icon-circle-left {
+      display: none;
+    }
+  }
+}
+</style>

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -16,6 +16,7 @@ export default new Vuex.Store({
     updateAvailable: false,
     updateChecked: false,
     visible: true,
+    minimised: false,
     isFullName: false,
   },
 
@@ -58,6 +59,9 @@ export default new Vuex.Store({
     },
     setUpdateChecked(state, boolean) {
       state.updateChecked = boolean;
+    },
+    setMinimised(state, boolean) {
+      state.minimised = boolean;
     },
     setVisible(state, boolean) {
       state.visible = boolean;
@@ -105,6 +109,9 @@ export default new Vuex.Store({
     },
     setUpdateChecked(context, boolean) {
       context.commit("setUpdateChecked", boolean);
+    },
+    setMinimised(context, boolean) {
+      context.commit("setMinimised", boolean);
     },
     setVisible(context, boolean) {
       context.commit("setVisible", boolean);


### PR DESCRIPTION
If you're on a call that where you might not need this feature it can become distractive

This feature adds the ability to collapse it.

it uses the existing store to store the minimised state of tray and applies CSS classes that transform position.

Fixes: https://github.com/LeePorte/hand-signals/issues/14

### Expanded
<img width="689" alt="Screenshot 2020-10-09 at 17 38 54" src="https://user-images.githubusercontent.com/3758555/95609311-67cebf80-0a56-11eb-8282-e75ba2439cae.png">

### Collapsed
<img width="722" alt="Screenshot 2020-10-09 at 17 39 11" src="https://user-images.githubusercontent.com/3758555/95609313-6a311980-0a56-11eb-9ca5-b9f7e31c53aa.png">

How to test
-----
- checkout branch
- run `npm install` (on first use)
- run `npm run build`
- Go to chrome://extensions/.
- At the top right, turn on Developer mode.
- Click Load unpacked.
- Find and select the `extension` folder inside the repo folder
